### PR TITLE
implement add method in wesminsterShoppingManager

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,6 +5,14 @@
     <artifactId>Shopping</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
+    <dependencies>
+        <dependency>
+            <groupId>ch.softappeal.yass</groupId>
+            <artifactId>yass-generate</artifactId>
+            <version>66.0.0</version>
+            <type>jar</type>
+        </dependency>
+    </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>15</maven.compiler.source>

--- a/src/main/java/com/mycompany/shopping/ShoppingCart.java
+++ b/src/main/java/com/mycompany/shopping/ShoppingCart.java
@@ -40,6 +40,7 @@ public class ShoppingCart {
     public void removeProduct(Product product) {
         productList.remove(product);
     }
+    
 
     public double calculateTotalCost() {
         double totalCost = 0.0;

--- a/src/main/java/com/mycompany/shopping/ShoppingManager.java
+++ b/src/main/java/com/mycompany/shopping/ShoppingManager.java
@@ -1,0 +1,18 @@
+/*
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Interface.java to edit this template
+ */
+package com.mycompany.shopping;
+
+/**
+ *
+ * @author rajeen
+ */
+public interface ShoppingManager {
+    
+    void addProduct();
+    void removeProduct();
+    void printProducts();
+    void saveProducts();
+    
+}

--- a/src/main/java/com/mycompany/shopping/WestminsterShoppingManager.java
+++ b/src/main/java/com/mycompany/shopping/WestminsterShoppingManager.java
@@ -1,0 +1,111 @@
+/*
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
+ */
+package com.mycompany.shopping;
+
+/**
+ *
+ * @author rajeen
+ */
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Scanner;
+
+public class WestminsterShoppingManager implements ShoppingManager {
+
+    private static WestminsterShoppingManager instance;
+    //product list in the system  
+    private final List<Product> productListSystem;  
+
+    // Private constructor to avoid instanziation of object outside the class
+    private WestminsterShoppingManager() {
+        this.productListSystem=new ArrayList<>();
+    }
+
+    //enable global level access to ShoppingManager instance
+
+    public static WestminsterShoppingManager getInstance() {
+        if (instance == null) {
+            instance = new WestminsterShoppingManager();
+        }
+        return instance;
+    }
+
+    // Other methods and fields as before...
+
+    // Method to display the console menu using a do-while loop
+    public void displayConsoleMenu() {
+        Scanner scanner = new Scanner(System.in);
+        int choice;
+
+        do {
+            System.out.println("===== Console Menu =====");
+            System.out.println("1. Add Product");
+            System.out.println("2. Delete Product");
+            System.out.println("3. Display Product List");
+            System.out.println("4. Save Product List to File");
+            System.out.println("5. Exit");
+            System.out.print("Enter your choice: ");
+
+            choice = scanner.nextInt();
+            scanner.nextLine();  // Consume newline
+
+            switch (choice) {
+                case 1:
+                    // Call addProduct method
+                    break;
+                case 2:
+                    // Call deleteProduct method
+                    break;
+                case 3:
+                    // Call displayProductList method
+                    break;
+                case 4:
+                    // Call saveProductListToFile method
+                    break;
+                case 5:
+                    System.out.println("Exiting the console menu.");
+                    break;
+                default:
+                    System.out.println("Invalid choice. Please try again.");
+            }
+        } while (choice != 5);
+    }
+    
+    //abstract methods from the ShoppingManager interface are implemented below
+
+    @Override
+    public void addProduct() {
+        
+        
+        
+        
+        if(productListSystem.size()<50){
+            productListSystem.add(product);
+        }
+        else{
+            System.out.println("System can onlt have 50 type of products !");
+        }
+    }
+
+    @Override
+    public void removeProduct() {
+        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public void printProducts() {
+        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public void saveProducts() {
+        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+    
+    
+
+    
+}
+

--- a/src/main/java/com/mycompany/shopping/productFactory.java
+++ b/src/main/java/com/mycompany/shopping/productFactory.java
@@ -1,18 +1,13 @@
 /*
  * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
  */
-
 package com.mycompany.shopping;
 
 /**
  *
  * @author rajeen
  */
-public class Shopping {
-
-    public static void main(String[] args) {
-
-        
-        
-    }
+public class productFactory {
+    
 }


### PR DESCRIPTION
created the WestminsterShoppingManager class which implement the interface ShoppingManager which have four methods.Out of the methods only the add method is implemented in this pull reuest.As product object which is created by user inputs is needed for the add method I have  decided to move logic of creation of the product to separate class called "productFactory".Logics for validation and getting inputs are in that class and will return a  user preferd type of product .This created product will pass for "add" method of the list  in the "addProduct" method of WestminsterShoppingManager class.